### PR TITLE
Fix doc generation for annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install -g mdjavadoc
 ```shell
 git clone https://github.com/TheAndroidMaster/mdjavadoc
 cd mdjavadoc/cli
-sudo npm install -g
+npm install
 sudo npm link
 ```
 

--- a/api/index.js
+++ b/api/index.js
@@ -393,7 +393,7 @@ function parseFile(file, prefix, options) {
 			declaration = content.substring(startIndex, startIndex + content.substring(startIndex).indexOf("\n"));
 		}
 		
-		type = type.concat((/([A-Z0-9a-z\.\<\> ]*)/g).exec(declaration.trim())[1].trim().split(" "));
+		type = type.concat((/([A-Z0-9a-z\@\.\<\>\s]*)/g).exec(declaration.trim())[1].trim().split(" "));
 		
 		let doc = {
 			name: type.pop(),


### PR DESCRIPTION
public @interface Annotation… {...} was generating ["public"] type array instead of ["public", "@interface", "Annotation"], so name of all annotation would be "public" in markdown.